### PR TITLE
Update to not require permissions by default.

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -18,8 +18,7 @@
 		"page": "background.html"
 	},
 	"options_page": "options.html",
-	"permissions": [
-		"tabs",
+	"optional_permissions": [
 		"http://*/",
 		"https://*/"
 	]

--- a/options.js
+++ b/options.js
@@ -133,9 +133,18 @@ function save() {
     } else {
         delete localStorage.green;
     }
-    
+
+    chrome.permissions.request({
+      origins:[localStorage.url]
+    }, function (granted) {
+      if (granted) {
+        chrome.extension.getBackgroundPage()["init"]();
+      } else {
+        markDirty();
+      }
+    });
+
     init();
-    chrome.extension.getBackgroundPage()["init"]();
 }
 
 function markDirty() {


### PR DESCRIPTION
Instead of using permissions use optional_permissions.
When a URL is entered, request permissions for that URL only.

The extension no longer needs "tabs" (which was unneeded anyway),
and will only get permissions to the appropriate URL instead of all
URLs.
